### PR TITLE
Use relative paths to support hosting the client code in a subdirectory.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,9 +5,9 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- bootstrap css -->
-        <link rel="stylesheet" href="/css/bootstrap.min.css">
+        <link rel="stylesheet" href="css/bootstrap.min.css">
         <!-- ui css -->
-        <link rel="stylesheet" href="/css/ui.css">
+        <link rel="stylesheet" href="css/ui.css">
         <title>Local Client UI</title>
     </head>
     <body>
@@ -240,10 +240,10 @@
             </div>
         </div>
         <!-- bootstrap js -->
-        <script src="/js/bootstrap.min.js"></script>
+        <script src="js/bootstrap.min.js"></script>
         <!-- socket.io js -->
-        <script src="/socket.io/socket.io.js"></script>
+        <script src="socket.io/socket.io.js"></script>
         <!-- ui js -->
-        <script src="/js/ui.js"></script>
+        <script src="js/ui.js"></script>
     </body>
 </html>

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -265,7 +265,7 @@ function addStatusRow(statusList, name, value) {
 
 setHandlers();
 
-const socket = io();
+const socket = io({path: new URL('socket.io', location).pathname});
 
 socket.on("connect", () => {
 });


### PR DESCRIPTION
This allows reverse-proxying the client web ui on an arbitrary port.

As a concrete example, I have the client running on my home server, and I reverse-proxy the UI to a URL like https://example.com/box-client/, but this requires that all resources are loaded relative to the /box-client/ path, rather than the root of the domain.